### PR TITLE
String boolean attr support

### DIFF
--- a/recipes/ami.rb
+++ b/recipes/ami.rb
@@ -1,6 +1,4 @@
-include_recipe 'chef_ruby' do
-  only_if { node['aws_developer_tools']['install_ruby?'] && node['aws_developer_tools']['install_ruby?'] != 'false' }
-end
+include_recipe 'chef_ruby' unless (!node['aws_developer_tools']['install_ruby?'] || node['aws_developer_tools']['install_ruby?'] == 'false')
 
 cli_tools 'ami' do
   source node['aws_developer_tools']['ami']['source']

--- a/recipes/ami.rb
+++ b/recipes/ami.rb
@@ -1,5 +1,5 @@
-if node['aws_developer_tools']['install_ruby?']
-   include_recipe 'chef_ruby'
+include_recipe 'chef_ruby' do
+  only_if { node['aws_developer_tools']['install_ruby?'] && node['aws_developer_tools']['install_ruby?'] != 'false' }
 end
 
 cli_tools 'ami' do

--- a/recipes/api.rb
+++ b/recipes/api.rb
@@ -3,7 +3,7 @@ cli_tools 'api' do
 end
 
 include_recipe 'java' do
-  only_if { node['aws_developer_tools']['install_java?'] }
+  only_if { node['aws_developer_tools']['install_java?'] && node['aws_developer_tools']['install_java?'] != 'false' }
 end
 
 template '/etc/profile.d/aws_keys.sh' do

--- a/recipes/api.rb
+++ b/recipes/api.rb
@@ -2,9 +2,7 @@ cli_tools 'api' do
   source node['aws_developer_tools']['api']['source']
 end
 
-include_recipe 'java' do
-  only_if { node['aws_developer_tools']['install_java?'] && node['aws_developer_tools']['install_java?'] != 'false' }
-end
+include_recipe 'java' unless (!node['aws_developer_tools']['install_java?'] || node['aws_developer_tools']['install_java?'] == 'false')
 
 template '/etc/profile.d/aws_keys.sh' do
   source 'aws_keys.sh.erb'


### PR DESCRIPTION
Because boolean is not yet supported in Chef metadata, any system that complies and uses the type String for setting node attributes will provide a value such as 'false' instead of false in the node (for example, RightScale).

Additionally, after checking, include_recipe does not support options such as not_if or only_if so we need to do ruby conditionals for the install_*? attributes.
