### PR TITLE
Making credentials file more configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,8 @@ default['aws_developer_tools']['ami']['install_target'] = default['aws_developer
 
 ## AWS Tools ##
 default['aws_developer_tools']['aws_tools_target'] = '/usr/local/share/aws_tools'
+default['aws_developer_tools']['aws_tools_credentials']['location'] = "#{node['aws_developer_tools']['aws_tools_target']}/credentials"
+default['aws_developer_tools']['aws_tools_credentials']['permission'] = 0400
 
 default['aws_developer_tools']['auto_scaling']['source'] = 'http://ec2-downloads.s3.amazonaws.com/AutoScaling-2011-01-01.zip'
 default['aws_developer_tools']['auto_scaling']['install_target'] = "#{default['aws_developer_tools']['aws_tools_target']}/auto_scaling"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default['aws_developer_tools']['ami']['install_target'] = default['aws_developer
 ## AWS Tools ##
 default['aws_developer_tools']['aws_tools_target'] = '/usr/local/share/aws_tools'
 default['aws_developer_tools']['aws_tools_credentials']['location'] = "#{node['aws_developer_tools']['aws_tools_target']}/credentials"
-default['aws_developer_tools']['aws_tools_credentials']['permission'] = 0400
+default['aws_developer_tools']['aws_tools_credentials']['permission'] = 0444
 
 default['aws_developer_tools']['auto_scaling']['source'] = 'http://ec2-downloads.s3.amazonaws.com/AutoScaling-2011-01-01.zip'
 default['aws_developer_tools']['auto_scaling']['install_target'] = "#{default['aws_developer_tools']['aws_tools_target']}/auto_scaling"

--- a/definitions/cli_tools.rb
+++ b/definitions/cli_tools.rb
@@ -39,7 +39,7 @@ define :cli_tools, :extension => '.zip' do
     end
   else
     template "#{node['aws_developer_tools']['aws_tools_target']}/credentials" do
-      mode 0444
+      mode 0400
     end
 
     template "/etc/profile.d/#{params[:name]}.sh" do

--- a/definitions/cli_tools.rb
+++ b/definitions/cli_tools.rb
@@ -38,8 +38,8 @@ define :cli_tools, :extension => '.zip' do
       mode 0755
     end
   else
-    template "#{node['aws_developer_tools']['aws_tools_target']}/credentials" do
-      mode 0400
+    template "#{node['aws_developer_tools']['aws_tools_credentials']['location']}" do
+      mode node['aws_developer_tools']['aws_tools_credentials']['permission']
     end
 
     template "/etc/profile.d/#{params[:name]}.sh" do

--- a/templates/default/aws_tools.sh.erb
+++ b/templates/default/aws_tools.sh.erb
@@ -1,1 +1,1 @@
-export AWS_CREDENTIAL_FILE=<%= node['aws_developer_tools']['aws_tools_target'] %>/credentials
+export AWS_CREDENTIAL_FILE=<%= node['aws_developer_tools']['aws_tools_credentials']['location'] %>


### PR DESCRIPTION
The location is hard coded in many places but what is more problematic that the permissions also. This is a problem since the hard coded permission is quite allowing so you need to take special care about restricting it. Exposing these parameters as attributes makes it easier to handle the credentials file
