### PR TITLE
Re-factoring download and extraction to enable hash based caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ API and AutoScaling Tools require java; by default, OpenJDK is installed. See th
 default['aws_developer_tools']['install_java?'] = true  # set to `false` if you'd rather install java yourself
 default['aws_developer_tools']['install_ruby?'] = true  # set to `false` if you'd rather install ruby yourself
 
+default['aws_developer_tools']['force_download?'] = false # set to `true` to disable hash based caching
+
 default['aws_developer_tools']['aws_access_key'] = 'Your Access Key'  # you must set this if installing the API tools.
 default['aws_developer_tools']['aws_secret_key'] = 'Your Secret Key'  # you must set this if installing the API tools.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,8 @@ default['aws_developer_tools']['install_java?'] = true
 default['aws_developer_tools']['install_ruby?'] = true
 default['aws_developer_tools']['deploy_key?']  = false
 
+default['aws_developer_tools']['force_download?'] = false
+
 default['aws_developer_tools']['aws_access_key'] = 'Your Access Key'
 default['aws_developer_tools']['aws_secret_key'] = 'Your Secret Key'
 

--- a/definitions/cli_tools.rb
+++ b/definitions/cli_tools.rb
@@ -5,11 +5,19 @@ define :cli_tools, :extension => '.zip' do
 
   remote_file "/tmp/#{params[:name] + params[:extension]}" do
     source params[:source]
+    use_conditional_get !node['aws_developer_tools']['force_download?']
+    use_etag true
+    use_last_modified false
   end
   
-  execute 'cleanup old installs and extract the aws tool' do
+  execute 'cleanup old installs' do
     cwd '/tmp'
-    command "rm -rf #{params[:name]} && mkdir #{params[:name]} && mv #{params[:name] + params[:extension]} #{params[:name]}/ && cd #{params[:name]} && unzip -o ./#{params[:name] + params[:extension]}"
+    command "rm -rf #{params[:name]} && mkdir #{params[:name]}"
+  end
+  
+  execute 'extract the aws tool' do
+    cwd "/tmp/#{params[:name]}"
+    command "unzip -o ../#{params[:name] + params[:extension]}"
   end
 
   ruby_block 'copy the tools to the target directory' do

--- a/metadata.rb
+++ b/metadata.rb
@@ -43,6 +43,13 @@ attribute "aws_developer_tools/deploy_key?",
   :choice => [ "true", "false" ],
   :default => "false"
 
+attribute "aws_developer_tools/force_download?",
+  :display_name => "Force download",
+  :description => "Whether to re-download archives even if file with same checksum exists",
+  :required => "optional",
+  :choice => [ "true", "false" ],
+  :default => "false"
+
 attribute "aws_developer_tools/aws_access_key",
   :display_name => "AWS Developer Tools access key",
   :description => "The AWS Access Key for use with AWS developer tools.",


### PR DESCRIPTION
The `remote_file` helper supports sending headers with checksum (and timestamp) to prevent downloading files if they are present already and matching the one to be downloaded. By not moving the downloaded zip files before extracting we can let this optimisation kick in. With an initial chef run there's no difference. However if you want to update a server by running recipes, it accelerates the process if you don't have to download the files again, but only if they are matching. I disabled the modification date based caching, since it might occur that the download is aborted leaving a damaged file with newer timestamp in place.
If you feel that this change backward compatibility, I'm happy to change the default value for the attribute controlling this behaviour to keep downloading the file even if there's a match.
